### PR TITLE
fix DeviceOp

### DIFF
--- a/tests/filecheck/dialects/aie.mlir
+++ b/tests/filecheck/dialects/aie.mlir
@@ -1,6 +1,0 @@
-// RUN: XDSL_ROUNDTRIP
-// RUN: AIE_ROUNDTRIP
-
-arith.constant 5 : i32
-
-// CHECK: arith.constant 5 : i32

--- a/tests/filecheck/dialects/aie/device_op.mlir
+++ b/tests/filecheck/dialects/aie/device_op.mlir
@@ -1,0 +1,111 @@
+// RUN: XDSL_ROUNDTRIP
+// RUN: XDSL_GENERIC_ROUNDTRIP
+// RUN: AIE_ROUNDTRIP
+// RUN: AIE_GENERIC_ROUNDTRIP
+
+// operation: aie.device
+
+aie.device(xcvc1902) {
+	arith.constant 1 : i32
+}
+
+aie.device(xcve2302) {
+	arith.constant 1 : i32
+}
+
+aie.device(xcve2802) {
+	arith.constant 1 : i32
+}
+
+aie.device(npu1) {
+	arith.constant 1 : i32
+}
+
+aie.device(npu1_1col) {
+	arith.constant 1 : i32
+}
+
+aie.device(npu1_2col) {
+	arith.constant 1 : i32
+}
+
+aie.device(npu1_3col) {
+	arith.constant 1 : i32
+}
+
+aie.device(npu1_4col) {
+	arith.constant 1 : i32
+}
+
+aie.device(npu2) {
+	arith.constant 1 : i32
+}
+
+// CHECK:      module {
+// CHECK-NEXT:   aie.device(xcvc1902) {
+// CHECK-NEXT:     %{{.*}} = arith.constant 1 : i32
+// CHECK-NEXT:   }
+// CHECK-NEXT:   aie.device(xcve2302) {
+// CHECK-NEXT:     %{{.*}}  = arith.constant 1 : i32
+// CHECK-NEXT:   }
+// CHECK-NEXT:   aie.device(xcve2802) {
+// CHECK-NEXT:     %{{.*}} = arith.constant 1 : i32
+// CHECK-NEXT:   }
+// CHECK-NEXT:   aie.device(npu1) {
+// CHECK-NEXT:     %{{.*}} = arith.constant 1 : i32
+// CHECK-NEXT:   }
+// CHECK-NEXT:   aie.device(npu1_1col) {
+// CHECK-NEXT:     %{{.*}} = arith.constant 1 : i32
+// CHECK-NEXT:   }
+// CHECK-NEXT:   aie.device(npu1_2col) {
+// CHECK-NEXT:     %{{.*}} = arith.constant 1 : i32
+// CHECK-NEXT:   }
+// CHECK-NEXT:   aie.device(npu1_3col) {
+// CHECK-NEXT:     %{{.*}} = arith.constant 1 : i32
+// CHECK-NEXT:   }
+// CHECK-NEXT:   aie.device(npu1_4col) {
+// CHECK-NEXT:     %{{.*}} = arith.constant 1 : i32
+// CHECK-NEXT:   }
+// CHECK-NEXT:   aie.device(npu2) {
+// CHECK-NEXT:     %{{.*}} = arith.constant 1 : i32
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+
+// CHECK-GENERIC:      "builtin.module"() ({
+// CHECK-GENERIC-NEXT:   "aie.device"() <{{{["]?}}device{{["]?}} = 1 : i32}> ({
+// CHECK-GENERIC-NEXT:     %{{.*}} = "arith.constant"() <{{{["]?}}value{{["]?}} = 1 : i32}> : () -> i32
+// CHECK-GENERIC-NEXT:     "aie.end"() : () -> ()
+// CHECK-GENERIC-NEXT:   }) : () -> ()
+// CHECK-GENERIC-NEXT:   "aie.device"() <{{{["]?}}device{{["]?}} = 2 : i32}> ({
+// CHECK-GENERIC-NEXT:     %{{.*}} = "arith.constant"() <{{{["]?}}value{{["]?}} = 1 : i32}> : () -> i32
+// CHECK-GENERIC-NEXT:     "aie.end"() : () -> ()
+// CHECK-GENERIC-NEXT:   }) : () -> ()
+// CHECK-GENERIC-NEXT:   "aie.device"() <{{{["]?}}device{{["]?}} = 3 : i32}> ({
+// CHECK-GENERIC-NEXT:     %{{.*}} = "arith.constant"() <{{{["]?}}value{{["]?}} = 1 : i32}> : () -> i32
+// CHECK-GENERIC-NEXT:     "aie.end"() : () -> ()
+// CHECK-GENERIC-NEXT:   }) : () -> ()
+// CHECK-GENERIC-NEXT:   "aie.device"() <{{{["]?}}device{{["]?}} = 4 : i32}> ({
+// CHECK-GENERIC-NEXT:     %{{.*}} = "arith.constant"() <{{{["]?}}value{{["]?}} = 1 : i32}> : () -> i32
+// CHECK-GENERIC-NEXT:     "aie.end"() : () -> ()
+// CHECK-GENERIC-NEXT:   }) : () -> ()
+// CHECK-GENERIC-NEXT:   "aie.device"() <{{{["]?}}device{{["]?}} = 5 : i32}> ({
+// CHECK-GENERIC-NEXT:     %{{.*}} = "arith.constant"() <{{{["]?}}value{{["]?}} = 1 : i32}> : () -> i32
+// CHECK-GENERIC-NEXT:     "aie.end"() : () -> ()
+// CHECK-GENERIC-NEXT:   }) : () -> ()
+// CHECK-GENERIC-NEXT:   "aie.device"() <{{{["]?}}device{{["]?}} = 6 : i32}> ({
+// CHECK-GENERIC-NEXT:     %{{.*}} = "arith.constant"() <{{{["]?}}value{{["]?}} = 1 : i32}> : () -> i32
+// CHECK-GENERIC-NEXT:     "aie.end"() : () -> ()
+// CHECK-GENERIC-NEXT:   }) : () -> ()
+// CHECK-GENERIC-NEXT:   "aie.device"() <{{{["]?}}device{{["]?}} = 7 : i32}> ({
+// CHECK-GENERIC-NEXT:     %{{.*}} = "arith.constant"() <{{{["]?}}value{{["]?}} = 1 : i32}> : () -> i32
+// CHECK-GENERIC-NEXT:     "aie.end"() : () -> ()
+// CHECK-GENERIC-NEXT:   }) : () -> ()
+// CHECK-GENERIC-NEXT:   "aie.device"() <{{{["]?}}device{{["]?}} = 8 : i32}> ({
+// CHECK-GENERIC-NEXT:     %{{.*}} = "arith.constant"() <{{{["]?}}value{{["]?}} = 1 : i32}> : () -> i32
+// CHECK-GENERIC-NEXT:     "aie.end"() : () -> ()
+// CHECK-GENERIC-NEXT:   }) : () -> ()
+// CHECK-GENERIC-NEXT:   "aie.device"() <{{{["]?}}device{{["]?}} = 9 : i32}> ({
+// CHECK-GENERIC-NEXT:     %{{.*}} = "arith.constant"() <{{{["]?}}value{{["]?}} = 1 : i32}> : () -> i32
+// CHECK-GENERIC-NEXT:     "aie.end"() : () -> ()
+// CHECK-GENERIC-NEXT:   }) : () -> ()
+// CHECK-GENERIC-NEXT: }) : () -> ()

--- a/xdsl_aie/dialects/aie.py
+++ b/xdsl_aie/dialects/aie.py
@@ -8,8 +8,9 @@ of the original dialect can be found here https://xilinx.github.io/mlir-aie/AIED
 from __future__ import annotations
 
 from collections.abc import Iterable, Sequence
-from typing import Generic, Self
+from typing import Generic
 
+from typing_extensions import Self
 from xdsl.dialects import builtin
 from xdsl.dialects.builtin import (
     I32,

--- a/xdsl_aie/dialects/aie.py
+++ b/xdsl_aie/dialects/aie.py
@@ -7,9 +7,8 @@ of the original dialect can be found here https://xilinx.github.io/mlir-aie/AIED
 
 from __future__ import annotations
 
-from collections.abc import Iterable
-from enum import auto
-from typing import Generic
+from collections.abc import Iterable, Sequence
+from typing import Generic, Self
 
 from xdsl.dialects import builtin
 from xdsl.dialects.builtin import (
@@ -52,7 +51,7 @@ from xdsl.irdl import (
     irdl_op_definition,
     operand_def,
     opt_attr_def,
-    opt_region_def,
+    prop_def,
     region_def,
     result_def,
     successor_def,
@@ -64,10 +63,10 @@ from xdsl.printer import Printer
 from xdsl.traits import (
     HasParent,
     IsTerminator,
-    NoTerminator,
     SingleBlockImplicitTerminator,
     SymbolOpInterface,
     SymbolTable,
+    ensure_terminator,
 )
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
@@ -75,13 +74,29 @@ from xdsl.utils.hints import isa
 CASCADE_SIZE = 384
 
 
-class AIEDeviceEnum(StrEnum):
-    xcvc1902 = auto()
+class IntStrEnum(StrEnum):
+    @classmethod
+    def get_sequence(cls) -> Sequence[Self]:
+        return tuple(x for x in cls)
+
+    @classmethod
+    def from_int(cls, value: int) -> Self:
+        return cls.get_sequence()[value - 1]
+
+    def get_int(self) -> int:
+        return self.get_sequence().index(self) + 1
 
 
-@irdl_attr_definition
-class AIEDeviceAttr(EnumAttribute[AIEDeviceEnum]):
-    name = "aie.device_attr"
+class AIEDeviceEnum(IntStrEnum):
+    xcvc1902 = "xcvc1902"
+    xcve2302 = "xcve2302"
+    xcve2802 = "xcve2802"
+    npu1 = "npu1"
+    npu1_1col = "npu1_1col"
+    npu1_2col = "npu1_2col"
+    npu1_3col = "npu1_3col"
+    npu1_4col = "npu1_4col"
+    npu2 = "npu2"
 
 
 class ObjectFifoPortEnum(StrEnum):
@@ -616,34 +631,50 @@ class DebugOp(IRDLOperation):
 
 
 @irdl_op_definition
+class EndOp(IRDLOperation):
+    name = "aie.end"
+
+    def __init__(self):
+        super().__init__()
+
+    traits = traits_def(IsTerminator())
+
+    assembly_format = "attr-dict"
+
+
+@irdl_op_definition
 class DeviceOp(IRDLOperation):
     name = "aie.device"
 
-    region = opt_region_def()
+    region = region_def("single_block")
 
-    device = attr_def(AIEDeviceAttr)
-    traits = traits_def(SymbolTable(), NoTerminator(), HasParent(ModuleOp))
+    device = prop_def(IntegerAttr[IntegerType])
+    traits = traits_def(
+        SymbolTable(), SingleBlockImplicitTerminator(EndOp), HasParent(ModuleOp)
+    )
 
-    def __init__(self, device: AIEDeviceAttr, region: Region):
-        super().__init__(attributes={"device": device}, regions=[region])
+    def __init__(self, device: IntegerAttr[IntegerType], region: Region):
+        super().__init__(properties={"device": device}, regions=[region])
 
     def print(self, printer: Printer):
         printer.print("(")
-        device_str = "xcvc1902" if self.device.data == AIEDeviceEnum.xcvc1902 else ""
-        printer.print(device_str)
+        printer.print(AIEDeviceEnum.from_int(self.device.value.data).value)
         printer.print(") ")
-        if self.region is not None:
-            printer.print_region(self.region)
+        printer.print_region(self.region, print_block_terminators=False)
 
     @classmethod
     def parse(cls, parser: Parser) -> DeviceOp:
         parser.parse_characters("(")
-
-        device = AIEDeviceAttr(AIEDeviceAttr.parse_parameter(parser))
+        device = parser.parse_str_enum(AIEDeviceEnum)
         parser.parse_characters(")")
         region = parser.parse_region()
 
-        return DeviceOp(device, region)
+        device_op = cls(IntegerAttr(device.get_int(), 32), region)
+
+        for trait in device_op.get_traits_of_type(SingleBlockImplicitTerminator):
+            ensure_terminator(device_op, trait)
+
+        return device_op
 
 
 @irdl_op_definition
@@ -1162,18 +1193,6 @@ class PLIOOp(IRDLOperation):
 
     def __init__(self, col: IntegerAttr[IntegerType]):
         super().__init__(attributes={"col": col}, result_types=[IndexType()])
-
-
-@irdl_op_definition
-class EndOp(IRDLOperation):
-    name = "aie.end"
-
-    def __init__(self):
-        super().__init__()
-
-    traits = traits_def(IsTerminator())
-
-    assembly_format = "attr-dict"
 
 
 @irdl_op_definition


### PR DESCRIPTION
main changes:

- DeviceAttr is not a StrEnumAttr, but an I32EnumAttribute, which xdsl does not support, but can be mimicked with integerattrs and custom printing, created a helper enum class for this that could maybe be used to add support for this in xDSL (https://xdsl.zulipchat.com/#narrow/channel/364199-Beginners/topic/I32EnumAttr.20in.20xDSL)
- added filechecks for the device op
- added other supported devices
