### PR TITLE
Migrate dma_bd and dma_configure_task to mlir-aie v1.4.0

### DIFF
--- a/.github/workflows/ci-aie.yml
+++ b/.github/workflows/ci-aie.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      MLIR-AIE-Version: 1.3.0
+      MLIR-AIE-Version: 1.4.0
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
@@ -42,7 +42,7 @@ jobs:
       - name: Download and setup MLIR-AIE
         if: steps.cache-binary.outputs.cache-hit != 'true'
         run: |
-          wget -q https://github.com/Xilinx/mlir-aie/releases/download/v${{ env.MLIR-AIE-Version }}/mlir_aie-${{ env.MLIR-AIE-Version }}-cp310-cp310-manylinux_2_35_x86_64.whl -O mlir_aie.whl
+          wget -q https://github.com/Xilinx/mlir-aie/releases/download/v${{ env.MLIR-AIE-Version }}/mlir_aie-${{ env.MLIR-AIE-Version }}-cp311-cp311-manylinux_2_35_x86_64.whl -O mlir_aie.whl
           unzip -q mlir_aie.whl
       - name: Add MLIR-AIE to PATH
         run: |

--- a/tests/filecheck/dialects/aie/dma_bd_ops.mlir
+++ b/tests/filecheck/dialects/aie/dma_bd_ops.mlir
@@ -5,29 +5,20 @@
   %0 = memref.alloc() : memref<8xi16>
   %1 = memref.alloc() : memref<32xi8>
   %2 = memref.alloc() : memref<10xi32>
-  "aie.dma_bd"(%0) <{bd_id = 7 : i32, len = 8 : i32, offset = 0 : i32}> : (memref<8xi16>) -> ()
-  "aie.dma_bd"(%2) <{bd_id = 8 : i32, len = 10 : i32, offset = 0 : i32}> : (memref<10xi32>) -> ()
-  "aie.dma_bd"(%1) <{bd_id = 1 : i32, burst_length = 64 : i32, len = 16 : i32, offset = 4 : i32}> : (memref<32xi8>) -> ()
-  "aie.dma_bd"(%0) <{bd_id = 0 : i32, len = 8 : i32, offset = 0 : i32}> : (memref<8xi16>) -> ()
-  "aie.dma_bd"(%2) <{bd_id = 1 : i32, len = 10 : i32, offset = 2 : i32}> : (memref<10xi32>) -> ()
-  "aie.dma_bd"(%0) <{bd_id = 2 : i32, len = 10 : i32, offset = 2 : i32}> : (memref<8xi16>) -> ()
-  "aie.dma_bd"(%1) <{bd_id = 0 : i32, dimensions = #aie<bd_dim_layout_array[<size = 2, stride = 4>, <size = 2, stride = 8>, <size = 4, stride = 1>]>, len = 16 : i32, offset = 4 : i32}> : (memref<32xi8>) -> ()
-  "aie.dma_bd"(%1) <{bd_id = 0 : i32, dimensions = #aie<bd_dim_layout_array[<size = 2, stride = 4>, <size = 2, stride = 8>, <size = 4, stride = 1>]>, len = 16 : i32, offset = 4 : i32}> : (memref<32xi8>) -> ()
-  "aie.dma_bd"(%1) <{bd_id = 0 : i32, len = 16 : i32, offset = 4 : i32}> : (memref<32xi8>) -> ()
+  "aie.dma_bd"(%0) <{bd_id = 7 : i32, static_len = 8 : i32, static_offset = 0 : i32, operandSegmentSizes = array<i32: 1, 0, 0, 0, 0>}> : (memref<8xi16>) -> ()
+  "aie.dma_bd"(%2) <{bd_id = 8 : i32, static_len = 10 : i32, static_offset = 0 : i32, operandSegmentSizes = array<i32: 1, 0, 0, 0, 0>}> : (memref<10xi32>) -> ()
+  "aie.dma_bd"(%1) <{bd_id = 1 : i32, burst_length = 64 : i32, static_len = 16 : i32, static_offset = 4 : i32, operandSegmentSizes = array<i32: 1, 0, 0, 0, 0>}> : (memref<32xi8>) -> ()
+  "aie.dma_bd"(%1) <{bd_id = 0 : i32, static_sizes = array<i64: 2, 2, 4>, static_strides = array<i64: 4, 8, 1>, static_len = 16 : i32, static_offset = 4 : i32, operandSegmentSizes = array<i32: 1, 0, 0, 0, 0>}> : (memref<32xi8>) -> ()
+  "aie.dma_bd"(%1) <{bd_id = 0 : i32, static_len = 16 : i32, static_offset = 4 : i32, operandSegmentSizes = array<i32: 1, 0, 0, 0, 0>}> : (memref<32xi8>) -> ()
 }) : () -> ()
-
 
 // CHECK-GENERIC:      "builtin.module"() ({
 // CHECK-GENERIC-NEXT:   %0 = "memref.alloc"() <{operandSegmentSizes = array<i32: 0, 0>}> : () -> memref<8xi16>
 // CHECK-GENERIC-NEXT:   %1 = "memref.alloc"() <{operandSegmentSizes = array<i32: 0, 0>}> : () -> memref<32xi8>
 // CHECK-GENERIC-NEXT:   %2 = "memref.alloc"() <{operandSegmentSizes = array<i32: 0, 0>}> : () -> memref<10xi32>
-// CHECK-GENERIC-NEXT:   "aie.dma_bd"(%0) <{bd_id = 7 : i32, len = 8 : i32, offset = 0 : i32}> : (memref<8xi16>) -> ()
-// CHECK-GENERIC-NEXT:   "aie.dma_bd"(%2) <{bd_id = 8 : i32, len = 10 : i32, offset = 0 : i32}> : (memref<10xi32>) -> ()
-// CHECK-GENERIC-NEXT:   "aie.dma_bd"(%1) <{bd_id = 1 : i32, burst_length = 64 : i32, len = 16 : i32, offset = 4 : i32}> : (memref<32xi8>) -> ()
-// CHECK-GENERIC-NEXT:   "aie.dma_bd"(%0) <{bd_id = 0 : i32, len = 8 : i32, offset = 0 : i32}> : (memref<8xi16>) -> ()
-// CHECK-GENERIC-NEXT:   "aie.dma_bd"(%2) <{bd_id = 1 : i32, len = 10 : i32, offset = 2 : i32}> : (memref<10xi32>) -> ()
-// CHECK-GENERIC-NEXT:   "aie.dma_bd"(%0) <{bd_id = 2 : i32, len = 10 : i32, offset = 2 : i32}> : (memref<8xi16>) -> ()
-// CHECK-GENERIC-NEXT:   "aie.dma_bd"(%1) <{bd_id = 0 : i32, dimensions = #aie<bd_dim_layout_array[<size = 2, stride = 4>, <size = 2, stride = 8>, <size = 4, stride = 1>]>, len = 16 : i32, offset = 4 : i32}> : (memref<32xi8>) -> ()
-// CHECK-GENERIC-NEXT:   "aie.dma_bd"(%1) <{bd_id = 0 : i32, dimensions = #aie<bd_dim_layout_array[<size = 2, stride = 4>, <size = 2, stride = 8>, <size = 4, stride = 1>]>, len = 16 : i32, offset = 4 : i32}> : (memref<32xi8>) -> ()
-// CHECK-GENERIC-NEXT:   "aie.dma_bd"(%1) <{bd_id = 0 : i32, len = 16 : i32, offset = 4 : i32}> : (memref<32xi8>) -> ()
+// CHECK-GENERIC-NEXT:   "aie.dma_bd"(%0) <{bd_id = 7 : i32,{{.*}}static_len = 8 : i32, static_offset = 0 : i32{{.*}}}> : (memref<8xi16>) -> ()
+// CHECK-GENERIC-NEXT:   "aie.dma_bd"(%2) <{bd_id = 8 : i32,{{.*}}static_len = 10 : i32, static_offset = 0 : i32{{.*}}}> : (memref<10xi32>) -> ()
+// CHECK-GENERIC-NEXT:   "aie.dma_bd"(%1) <{bd_id = 1 : i32, burst_length = 64 : i32,{{.*}}static_len = 16 : i32, static_offset = 4 : i32{{.*}}}> : (memref<32xi8>) -> ()
+// CHECK-GENERIC-NEXT:   "aie.dma_bd"(%1) <{bd_id = 0 : i32,{{.*}}static_sizes = array<i64: 2, 2, 4>, static_strides = array<i64: 4, 8, 1>{{.*}}}> : (memref<32xi8>) -> ()
+// CHECK-GENERIC-NEXT:   "aie.dma_bd"(%1) <{bd_id = 0 : i32,{{.*}}static_len = 16 : i32, static_offset = 4 : i32{{.*}}}> : (memref<32xi8>) -> ()
 // CHECK-GENERIC-NEXT: }) : () -> ()

--- a/tests/filecheck/dialects/aiex/dma-tasks.mlir
+++ b/tests/filecheck/dialects/aiex/dma-tasks.mlir
@@ -7,12 +7,12 @@
     %1 = "aie.tile"() <{col = 2 : i32, row = 0 : i32}> : () -> index
     "aie.runtime_sequence"() <{sym_name = "sequence"}> ({
     ^bb0(%arg0 : memref<8xi16>, %arg1 : memref<10xi32>):
-      %2 = "aiex.dma_configure_task"(%0) <{channel = 0 : i32, direction = 1 : i32, issue_token = true}> ({
-        "aie.dma_bd"(%arg0) <{bd_id = 7 : i32, len = 8 : i32, offset = 0 : i32}> : (memref<8xi16>) -> ()
+      %2 = "aiex.dma_configure_task"(%0) <{channel = 0 : i32, direction = 1 : i32, issue_token = true, operandSegmentSizes = array<i32: 1, 0, 0>}> ({
+        "aie.dma_bd"(%arg0) <{bd_id = 7 : i32, static_len = 8 : i32, static_offset = 0 : i32, operandSegmentSizes = array<i32: 1, 0, 0, 0, 0>}> : (memref<8xi16>) -> ()
         "aie.end"() : () -> ()
       }) : (index) -> index
-      %3 = "aiex.dma_configure_task"(%1) <{channel = 1 : i32, direction = 0 : i32, issue_token = true, repeat_count = 2 : i32}> ({
-        "aie.dma_bd"(%arg1) <{bd_id = 8 : i32, len = 10 : i32, offset = 0 : i32}> : (memref<10xi32>) -> ()
+      %3 = "aiex.dma_configure_task"(%1) <{channel = 1 : i32, direction = 0 : i32, issue_token = true, repeat_count = 2 : i32, operandSegmentSizes = array<i32: 1, 0, 0>}> ({
+        "aie.dma_bd"(%arg1) <{bd_id = 8 : i32, static_len = 10 : i32, static_offset = 0 : i32, operandSegmentSizes = array<i32: 1, 0, 0, 0, 0>}> : (memref<10xi32>) -> ()
         "aie.end"() : () -> ()
       }) : (index) -> index
       "aiex.dma_start_task"(%2) : (index) -> ()
@@ -31,12 +31,12 @@
 // CHECK-GENERIC-NEXT:     %1 = "aie.tile"() <{col = 2 : i32, row = 0 : i32}> : () -> index
 // CHECK-GENERIC-NEXT:     "aie.runtime_sequence"() <{sym_name = "sequence"}> ({
 // CHECK-GENERIC-NEXT:     ^0(%arg0 : memref<8xi16>, %arg1 : memref<10xi32>):
-// CHECK-GENERIC-NEXT:       %2 = "aiex.dma_configure_task"(%0) <{channel = 0 : i32, direction = 1 : i32, issue_token = true}> ({
-// CHECK-GENERIC-NEXT:         "aie.dma_bd"(%arg0) <{bd_id = 7 : i32, len = 8 : i32, offset = 0 : i32}> : (memref<8xi16>) -> ()
+// CHECK-GENERIC-NEXT:       %2 = "aiex.dma_configure_task"(%0) <{{{.*}}}> ({
+// CHECK-GENERIC-NEXT:         "aie.dma_bd"(%arg0) <{{{.*}}}> : (memref<8xi16>) -> ()
 // CHECK-GENERIC-NEXT:         "aie.end"() : () -> ()
 // CHECK-GENERIC-NEXT:       }) : (index) -> index
-// CHECK-GENERIC-NEXT:       %3 = "aiex.dma_configure_task"(%1) <{channel = 1 : i32, direction = 0 : i32, issue_token = true, repeat_count = 2 : i32}> ({
-// CHECK-GENERIC-NEXT:         "aie.dma_bd"(%arg1) <{bd_id = 8 : i32, len = 10 : i32, offset = 0 : i32}> : (memref<10xi32>) -> ()
+// CHECK-GENERIC-NEXT:       %3 = "aiex.dma_configure_task"(%1) <{{{.*}}}> ({
+// CHECK-GENERIC-NEXT:         "aie.dma_bd"(%arg1) <{{{.*}}}> : (memref<10xi32>) -> ()
 // CHECK-GENERIC-NEXT:         "aie.end"() : () -> ()
 // CHECK-GENERIC-NEXT:       }) : (index) -> index
 // CHECK-GENERIC-NEXT:       "aiex.dma_start_task"(%2) : (index) -> ()
@@ -56,14 +56,14 @@
     %1 = "aie.tile"() <{col = 0 : i32, row = 2 : i32}> : () -> index
     "aie.runtime_sequence"() <{sym_name = "sequence"}> ({
     ^bb0(%arg0: memref<8xi16>, %arg1: memref<10xi32>):
-      %2 = "aiex.dma_configure_task"(%0) <{channel = 0 : i32, direction = 1 : i32}> ({
-        "aie.dma_bd"(%arg0) <{bd_id = 0 : i32, len = 8 : i32, offset = 0 : i32}> : (memref<8xi16>) -> ()
+      %2 = "aiex.dma_configure_task"(%0) <{channel = 0 : i32, direction = 1 : i32, operandSegmentSizes = array<i32: 1, 0, 0>}> ({
+        "aie.dma_bd"(%arg0) <{bd_id = 0 : i32, static_len = 8 : i32, static_offset = 0 : i32, operandSegmentSizes = array<i32: 1, 0, 0, 0, 0>}> : (memref<8xi16>) -> ()
         "aie.next_bd"()[^bb1] : () -> ()
       ^bb1:  // pred: ^bb0
-        "aie.dma_bd"(%arg1) <{bd_id = 1 : i32, len = 10 : i32, offset = 2 : i32}> : (memref<10xi32>) -> ()
+        "aie.dma_bd"(%arg1) <{bd_id = 1 : i32, static_len = 10 : i32, static_offset = 2 : i32, operandSegmentSizes = array<i32: 1, 0, 0, 0, 0>}> : (memref<10xi32>) -> ()
         "aie.next_bd"()[^bb2] : () -> ()
       ^bb2:  // pred: ^bb1
-        "aie.dma_bd"(%arg0) <{bd_id = 2 : i32, len = 10 : i32, offset = 2 : i32}> : (memref<8xi16>) -> ()
+        "aie.dma_bd"(%arg0) <{bd_id = 2 : i32, static_len = 10 : i32, static_offset = 2 : i32, operandSegmentSizes = array<i32: 1, 0, 0, 0, 0>}> : (memref<8xi16>) -> ()
         "aie.end"() : () -> ()
       }) : (index) -> index
     }) : () -> ()
@@ -78,14 +78,14 @@
 // CHECK-GENERIC-NEXT:     %1 = "aie.tile"() <{col = 0 : i32, row = 2 : i32}> : () -> index
 // CHECK-GENERIC-NEXT:     "aie.runtime_sequence"() <{sym_name = "sequence"}> ({
 // CHECK-GENERIC-NEXT:     ^0(%arg0 : memref<8xi16>, %arg1 : memref<10xi32>):
-// CHECK-GENERIC-NEXT:       %2 = "aiex.dma_configure_task"(%0) <{channel = 0 : i32, direction = 1 : i32}> ({
-// CHECK-GENERIC-NEXT:         "aie.dma_bd"(%arg0) <{bd_id = 0 : i32, len = 8 : i32, offset = 0 : i32}> : (memref<8xi16>) -> ()
+// CHECK-GENERIC-NEXT:       %2 = "aiex.dma_configure_task"(%0) <{{{.*}}}> ({
+// CHECK-GENERIC-NEXT:         "aie.dma_bd"(%arg0) <{{{.*}}}> : (memref<8xi16>) -> ()
 // CHECK-GENERIC-NEXT:         "aie.next_bd"() [^1] : () -> ()
 // CHECK-GENERIC-NEXT:       ^1:
-// CHECK-GENERIC-NEXT:         "aie.dma_bd"(%arg1) <{bd_id = 1 : i32, len = 10 : i32, offset = 2 : i32}> : (memref<10xi32>) -> ()
+// CHECK-GENERIC-NEXT:         "aie.dma_bd"(%arg1) <{{{.*}}}> : (memref<10xi32>) -> ()
 // CHECK-GENERIC-NEXT:         "aie.next_bd"() [^2] : () -> ()
 // CHECK-GENERIC-NEXT:       ^2:
-// CHECK-GENERIC-NEXT:         "aie.dma_bd"(%arg0) <{bd_id = 2 : i32, len = 10 : i32, offset = 2 : i32}> : (memref<8xi16>) -> ()
+// CHECK-GENERIC-NEXT:         "aie.dma_bd"(%arg0) <{{{.*}}}> : (memref<8xi16>) -> ()
 // CHECK-GENERIC-NEXT:         "aie.end"() : () -> ()
 // CHECK-GENERIC-NEXT:       }) : (index) -> index
 // CHECK-GENERIC-NEXT:     }) : () -> ()

--- a/xdsl_aie/dialects/aie.py
+++ b/xdsl_aie/dialects/aie.py
@@ -49,6 +49,7 @@ from xdsl.ir import (
     TypeAttribute,
 )
 from xdsl.irdl import (
+    AttrSizedOperandSegments,
     IRDLOperation,
     ParameterDef,
     attr_def,
@@ -56,6 +57,7 @@ from xdsl.irdl import (
     irdl_op_definition,
     operand_def,
     opt_attr_def,
+    opt_operand_def,
     opt_prop_def,
     prop_def,
     region_def,
@@ -516,58 +518,80 @@ class DMABDOp(IRDLOperation):
 
     buffer = operand_def(builtin.MemRefType)
 
-    offset = prop_def(IntegerAttr[IntegerType])
-    len = opt_prop_def(IntegerAttr[IntegerType])
+    # offset and len are in elements, not bytes, and are either a static
+    # attribute or a runtime value. Absent, they mean zero and the whole buffer.
+    offset = opt_operand_def(builtin.i32)
+    len = opt_operand_def(builtin.i32)
+    static_offset = opt_prop_def(IntegerAttr[IntegerType])
+    static_len = opt_prop_def(IntegerAttr[IntegerType])
 
-    dimensions = opt_prop_def(BDDimLayoutArrayAttr)
+    # n-d addressing, outermost dimension first, mixed static and dynamic the
+    # same way as aiex.npu.dma_memcpy_nd.
+    sizes = var_operand_def(builtin.i64)
+    strides = var_operand_def(builtin.i64)
+    static_sizes = opt_prop_def(builtin.DenseArrayBase)
+    static_strides = opt_prop_def(builtin.DenseArrayBase)
+
     pad_dimensions = opt_prop_def(BDDimLayoutArrayAttr)
-
     pad_value = opt_prop_def(IntegerAttr[IntegerType])
     bd_id = opt_prop_def(IntegerAttr[IntegerType])
 
     packet = opt_prop_def(Attribute)
 
     burst_length = opt_prop_def(IntegerAttr[IntegerType])
+    offset_parameter = opt_prop_def(builtin.SymbolRefAttr)
+    offset_state_table_idx = opt_prop_def(IntegerAttr[IntegerType])
     next_bd_id = opt_prop_def(IntegerAttr[IntegerType])
+
+    irdl_options = [AttrSizedOperandSegments(as_property=True)]
 
     def __init__(
         self,
         buffer: Operation | SSAValue,
-        offset: int | IntegerAttr[IntegerType],
+        offset: int | IntegerAttr[IntegerType] | None = None,
         len: int | IntegerAttr[IntegerType] | None = None,
-        dimensions: BDDimLayoutArrayAttr | None = None,
+        sizes: Sequence[int] | None = None,
+        strides: Sequence[int] | None = None,
         pad_dimensions: BDDimLayoutArrayAttr | None = None,
         pad_value: int | IntegerAttr[IntegerType] | None = None,
         bd_id: int | IntegerAttr[IntegerType] | None = None,
         packet: Attribute | None = None,
         burst_length: int | IntegerAttr[IntegerType] | None = None,
+        offset_parameter: builtin.SymbolRefAttr | None = None,
+        offset_state_table_idx: int | IntegerAttr[IntegerType] | None = None,
         next_bd_id: int | IntegerAttr[IntegerType] | None = None,
     ):
-        if isinstance(offset, int):
-            offset = IntegerAttr.from_int_and_width(offset, 32)
-        if isinstance(len, int):
-            len = IntegerAttr.from_int_and_width(len, 32)
-        if isinstance(pad_value, int):
-            pad_value = IntegerAttr.from_int_and_width(pad_value, 32)
-        if isinstance(bd_id, int):
-            bd_id = IntegerAttr.from_int_and_width(bd_id, 32)
-        if isinstance(burst_length, int):
-            burst_length = IntegerAttr.from_int_and_width(burst_length, 32)
-        if isinstance(next_bd_id, int):
-            next_bd_id = IntegerAttr.from_int_and_width(next_bd_id, 32)
+        def i32(value: int | IntegerAttr[IntegerType] | None):
+            return (
+                IntegerAttr.from_int_and_width(value, 32)
+                if isinstance(value, int)
+                else value
+            )
+
         super().__init__(
             properties={
-                "offset": offset,
-                "len": len,
-                "dimensions": dimensions,
+                "static_offset": i32(offset),
+                "static_len": i32(len),
+                "static_sizes": (
+                    builtin.DenseArrayBase.from_list(builtin.i64, sizes)
+                    if sizes is not None
+                    else None
+                ),
+                "static_strides": (
+                    builtin.DenseArrayBase.from_list(builtin.i64, strides)
+                    if strides is not None
+                    else None
+                ),
                 "pad_dimensions": pad_dimensions,
-                "pad_value": pad_value,
-                "bd_id": bd_id,
+                "pad_value": i32(pad_value),
+                "bd_id": i32(bd_id),
                 "packet": packet,
-                "burst_length": burst_length,
-                "next_bd_id": next_bd_id,
+                "burst_length": i32(burst_length),
+                "offset_parameter": offset_parameter,
+                "offset_state_table_idx": i32(offset_state_table_idx),
+                "next_bd_id": i32(next_bd_id),
             },
-            operands=[buffer],
+            operands=[buffer, None, None, [], []],
         )
 
 
@@ -1247,7 +1271,11 @@ class ObjectFifoOp(IRDLOperation):
             elemType,
             name,
             BDDimLayoutArrayAttr(BDDimLayoutArray(tuple())),
-            BDDimLayoutArrayArrayAttr(BDDimLayoutArrayArray(tuple(tuple()))),
+            BDDimLayoutArrayArrayAttr(
+                BDDimLayoutArrayArray(
+                    tuple(BDDimLayoutArray(tuple()) for _ in consumerTiles)
+                )
+            ),
             False,
             False,
             False,

--- a/xdsl_aie/dialects/aiex.py
+++ b/xdsl_aie/dialects/aiex.py
@@ -2,6 +2,7 @@ from collections.abc import Sequence
 from typing import cast
 
 from typing_extensions import Self
+from xdsl.dialects import builtin
 from xdsl.dialects.builtin import (
     BoolAttr,
     DenseArrayBase,
@@ -20,6 +21,7 @@ from xdsl.irdl import (
     ParsePropInAttrDict,
     irdl_op_definition,
     operand_def,
+    opt_operand_def,
     opt_prop_def,
     prop_def,
     region_def,
@@ -181,8 +183,11 @@ class DmaConfigureTaskOp(IRDLOperation):
     channel = prop_def(IntegerAttr[IntegerType])
     issue_token = opt_prop_def(BoolAttr)
     repeat_count = opt_prop_def(IntegerAttr[IntegerType])
+    repeat_count_val = opt_operand_def(builtin.i32)
+    bd_id_val = opt_operand_def(builtin.i32)
 
     traits = traits_def(HasParent(RuntimeSequenceOp))
+    irdl_options = [AttrSizedOperandSegments(as_property=True)]
 
     def __init__(
         self,
@@ -203,7 +208,7 @@ class DmaConfigureTaskOp(IRDLOperation):
             repeat = IntegerAttr.from_int_and_width(repeat, 32)
 
         super().__init__(
-            operands=[tile],
+            operands=[tile, None, None],
             properties={
                 "direction": direction,
                 "channel": channel,


### PR DESCRIPTION
mlir-aie v1.4.0 changed the assembly format and operand structure of `aie.dma_bd`, so the ops this dialect emits no longer parse. v1.3.5 silently dropped the new attributes rather than erroring, so the mismatch stays invisible until the emitted MLIR reaches `aie-opt`.

- `aie.dma_bd` takes `offset` and `len` as optional operands with `static_offset` and `static_len` beside them.
- `aie.dma_bd` replaces the `dimensions` attribute with `sizes` and `strides` operands plus `static_sizes` and `static_strides`.
- `aie.dma_bd` gains `offset_parameter` and `offset_state_table_idx`.
- `aie.dma_bd` and `aiex.dma_configure_task` carry `AttrSizedOperandSegments`.
- `aiex.dma_configure_task` gains the optional `repeat_count_val` and `bd_id_val` operands.
- `ObjectFifoOp.from_referenced_type` emits one `dimensionsFromStream` entry per consumer tile instead of a single empty one, which the printer rejected for multi-consumer fifos.
- Filecheck tests for both ops move to the new syntax.

Checked against the v1.4.0 `aie-opt`, where the filecheck suite passes and generated designs round-trip.
